### PR TITLE
any型警告の全解消・datasourcesテスト追加・.gitignore改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # Build output
 dist/
 
+# Test coverage
+coverage/
+
 # Logs
 logs
 *.log

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -70,13 +70,6 @@ export class RedashRateLimitError extends RedashError {
 /**
  * 与えられたエラーがRedashErrorかどうかをチェックする型ガード
  */
-export function isRedashError(error: any): error is RedashError {
-  return (
-    error instanceof RedashError ||
-    error instanceof RedashAuthenticationError ||
-    error instanceof RedashResourceNotFoundError ||
-    error instanceof RedashValidationError ||
-    error instanceof RedashServerError ||
-    error instanceof RedashRateLimitError
-  );
+export function isRedashError(error: unknown): error is RedashError {
+  return error instanceof RedashError;
 } 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -24,7 +24,7 @@ export interface QueryResult {
       type: string;
       friendly_name: string;
     }>;
-    rows: Array<Record<string, any>>;
+    rows: Array<Record<string, unknown>>;
   };
   data_source_id: number;
   runtime: number;
@@ -45,7 +45,7 @@ export interface Job {
   error?: string;
   query_result_id?: number;
   updated_at?: number;
-  result?: any;
+  result?: unknown;
 }
 
 /**
@@ -53,7 +53,7 @@ export interface Job {
  */
 export interface JobResponse {
   job?: Job;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 /**

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -84,7 +84,7 @@ export async function apiGet<T>(endpoint: string): Promise<T> {
 /**
  * Redash APIに対してPOSTリクエストを送信する
  */
-export async function apiPost<T, U = any>(endpoint: string, data: U): Promise<T> {
+export async function apiPost<T, U = unknown>(endpoint: string, data: U): Promise<T> {
   const { baseUrl } = getConfig();
   const url = `${baseUrl}${endpoint}`;
     

--- a/src/operations/datasources.test.ts
+++ b/src/operations/datasources.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listDataSources, getDataSource } from './datasources';
+
+vi.mock('../common/utils.js', () => ({
+  apiGet: vi.fn(),
+}));
+
+vi.mock('../config.js', () => ({
+  getConfig: () => ({
+    apiKey: 'test-key',
+    baseUrl: 'https://redash.example.com',
+  }),
+}));
+
+import { apiGet } from '../common/utils';
+
+const mockApiGet = vi.mocked(apiGet);
+
+describe('listDataSources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('データソース一覧を取得できる', async () => {
+    const mockSources = [
+      { id: 1, name: 'PostgreSQL', type: 'pg', syntax: 'sql', paused: false, pause_reason: null, supports_auto_limit: true, view_only: false },
+      { id: 2, name: 'MySQL', type: 'mysql', syntax: 'sql', paused: false, pause_reason: null, supports_auto_limit: true, view_only: false },
+    ];
+    mockApiGet.mockResolvedValue(mockSources);
+
+    const result = await listDataSources();
+    expect(result).toEqual(mockSources);
+    expect(mockApiGet).toHaveBeenCalledWith('/api/data_sources');
+  });
+
+  it('空の一覧を返せる', async () => {
+    mockApiGet.mockResolvedValue([]);
+
+    const result = await listDataSources();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getDataSource', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('特定のデータソースを取得できる', async () => {
+    const mockSource = {
+      id: 1,
+      name: 'PostgreSQL',
+      type: 'pg',
+      syntax: 'sql',
+      paused: false,
+      pause_reason: null,
+      supports_auto_limit: true,
+      view_only: false,
+    };
+    mockApiGet.mockResolvedValue(mockSource);
+
+    const result = await getDataSource(1);
+    expect(result).toEqual(mockSource);
+    expect(mockApiGet).toHaveBeenCalledWith('/api/data_sources/1');
+  });
+});


### PR DESCRIPTION
## Summary
- ESLint の `no-explicit-any` warning を全5件解消（`any` → `unknown` に置換）
- `datasources.ts` のユニットテスト3件を追加（カバレッジ 0% → 100%）
- `.gitignore` に `coverage/` ディレクトリを追加

## 変更詳細
- `errors.ts`: `isRedashError` の引数を `any` → `unknown` に変更。サブクラスの冗長な `instanceof` チェックを削除（`RedashError` だけで全サブクラスをカバー）
- `types.ts`: `Record<string, any>` → `Record<string, unknown>`、`result?: any` → `unknown`、インデックスシグネチャを `unknown` に
- `utils.ts`: `apiPost` のジェネリクスデフォルトを `U = any` → `U = unknown` に

## Test plan
- [x] `npm run lint` エラー 0、warning 0
- [x] `npm run typecheck` パス
- [x] `npm run test` で 48/48 テストパス