### PR TITLE
README改善: 3つの起動モードを分かりやすく記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,15 @@ node dist/index.js
 npx mcp-redash
 ```
 
-Claude DesktopまたはCursorのMCP設定例:
+Claude Codeの `.mcp.json` 設定例:
 
 ```json
 {
   "mcpServers": {
     "redash": {
+      "type": "stdio",
       "command": "npx",
-      "args": [
-        "mcp-redash"
-      ],
+      "args": ["mcp-redash"],
       "env": {
         "REDASH_API_KEY": "<YOUR_API_KEY>",
         "REDASH_BASE_URL": "https://redash.example.com"
@@ -112,17 +111,16 @@ Claude DesktopまたはCursorのMCP設定例:
 docker build -t yuki9541134/mcp-redash .
 ```
 
-Claude DesktopまたはCursorのMCP設定例:
+Claude Codeの `.mcp.json` 設定例:
 
 ```json
 {
   "mcpServers": {
     "redash": {
+      "type": "stdio",
       "command": "docker",
       "args": [
-        "run",
-        "-i",
-        "--rm",
+        "run", "-i", "--rm",
         "-e", "REDASH_API_KEY",
         "-e", "REDASH_BASE_URL",
         "yuki9541134/mcp-redash"

--- a/README.md
+++ b/README.md
@@ -153,9 +153,7 @@ node dist/index.js --streamable-http
 #### Docker
 
 ```sh
-docker run --rm -p 3000:3000 \
-  -e REDASH_API_KEY="<YOUR_API_KEY>" \
-  -e REDASH_BASE_URL="https://redash.example.com" \
+docker run --rm -p 3000:3000 --env-file .env \
   yuki9541134/mcp-redash --streamable-http
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,19 +65,14 @@ npm link
 
 ### stdio（デフォルト）
 
-標準入出力で通信するモードです。Claude DesktopやCursorなどのMCPクライアントから利用する場合はこちらを使用します。
-
-#### 開発時
+標準入出力で通信するモードです。MCPクライアントからローカルで利用する場合はこちらを使用します。
 
 ```bash
-npm run dev
-```
-
-#### ビルド後
-
-```bash
+npm run build
 node dist/index.js
 ```
+
+> 開発時は `npm run dev` でTypeScriptを直接実行できます。
 
 #### npxで利用する場合
 
@@ -138,17 +133,12 @@ Claude Codeの `.mcp.json` 設定例:
 
 HTTPサーバーとして起動し、Streamable HTTPプロトコルで通信するモードです。Webクライアントやリモート接続に適しています。
 
-#### 開発時
-
 ```bash
-npm run dev -- --streamable-http
-```
-
-#### ビルド後
-
-```bash
+npm run build
 node dist/index.js --streamable-http
 ```
+
+> 開発時は `npm run dev -- --streamable-http` でTypeScriptを直接実行できます。
 
 #### Docker
 
@@ -181,17 +171,12 @@ Claude Codeの `.mcp.json` 設定例:
 
 HTTPサーバーとして起動し、Server-Sent Events (SSE) で通信するモードです。
 
-#### 開発時
-
 ```bash
-npm run dev -- --sse
-```
-
-#### ビルド後
-
-```bash
+npm run build
 node dist/index.js --sse
 ```
+
+> 開発時は `npm run dev -- --sse` でTypeScriptを直接実行できます。
 
 エンドポイント:
 - `GET /sse` - SSE接続の確立

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm link
 | 通信方式 | 標準入出力 | HTTP | HTTP（Server-Sent Events） |
 | ポート | 不要 | 3000 | 3000 |
 | エンドポイント | - | `POST/GET/DELETE /mcp` | `GET /sse`, `POST /messages` |
-| 主な用途 | Claude Desktop, Cursor等 | Webクライアント, リモート接続 | レガシー互換 |
+| 主な用途 | ローカル利用 | リモート・複数クライアント共有 | レガシー互換 |
 
 > ポートは環境変数 `PORT` で変更できます（Streamable HTTP / SSE）。
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ docker run --rm -p 3000:3000 --env-file .env \
 - `GET /mcp` - SSEストリームの確立（サーバー → クライアント通知用）
 - `DELETE /mcp` - セッションの終了
 
+Claude Codeの `.mcp.json` 設定例:
+
+```json
+{
+  "mcpServers": {
+    "redash": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
 ### SSE（非推奨）
 
 > **非推奨**: SSEモードはレガシー互換のために残されています。新規利用にはStreamable HTTPモードを推奨します。
@@ -183,3 +196,16 @@ node dist/index.js --sse
 エンドポイント:
 - `GET /sse` - SSE接続の確立
 - `POST /messages` - メッセージの送信
+
+Claude Codeの `.mcp.json` 設定例:
+
+```json
+{
+  "mcpServers": {
+    "redash": {
+      "type": "sse",
+      "url": "http://localhost:3000/sse"
+    }
+  }
+}
+```


### PR DESCRIPTION
## 概要

READMEの起動方法セクションを再構成し、3つの起動モード（stdio / Streamable HTTP / SSE）の違いと使い方を分かりやすく整理しました。

## 変更内容

- 「起動モード」セクションを新設し、比較表で3モードを一覧化
- stdio（デフォルト）: npx / Docker / Claude Desktop設定例を集約
- Streamable HTTP: 起動コマンド・Docker例・エンドポイント説明を追加
- SSE: 非推奨であることを明記
- インストール手順を `git clone` からビルド・リンクまで一つにまとめた
- 旧セクション（「npxで利用する場合」「Dockerで利用する場合」「SSEモードで利用する場合」）を新構成に統合

## 確認方法

- READMEの内容を目視確認
- 3モードの起動コマンド（`npm run dev` / `npm run dev -- --streamable-http` / `npm run dev -- --sse`）が正常に動作することを確認済み