### PR TITLE
Docker Compose対応とPORT定義の一元化

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Redash APIキーを取得してください。
 
 * `REDASH_API_KEY`: RedashのAPIキー
 * `REDASH_BASE_URL`: RedashのURL（例: https://redash.example.com）
+* `PORT`（任意）: HTTPサーバーのポート番号（デフォルト: 3000、Streamable HTTP / SSE で使用）
 
 ### インストール
 
@@ -57,11 +58,9 @@ npm link
 |---|---|---|---|
 | 起動フラグ | なし | `--streamable-http` | `--sse` |
 | 通信方式 | 標準入出力 | HTTP | HTTP（Server-Sent Events） |
-| ポート | 不要 | 3000 | 3000 |
+| ポート | 不要 | デフォルト 3000 | デフォルト 3000 |
 | エンドポイント | - | `POST/GET/DELETE /mcp` | `GET /sse`, `POST /messages` |
 | 主な用途 | ローカル利用 | リモート・複数クライアント共有 | レガシー互換 |
-
-> ポートは環境変数 `PORT` で変更できます（Streamable HTTP / SSE）。
 
 ### stdio（デフォルト）
 
@@ -140,12 +139,13 @@ node dist/index.js --streamable-http
 
 > 開発時は `npm run dev -- --streamable-http` でTypeScriptを直接実行できます。
 
-#### Docker
+#### Docker Compose
 
 ```sh
-docker run --rm -p 3000:3000 --env-file .env \
-  yuki9541134/mcp-redash --streamable-http
+docker compose up -d
 ```
+
+> `.env` の `PORT` でポートを変更できます（デフォルト: 3000）。
 
 エンドポイント:
 - `POST /mcp` - リクエストの送信

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  mcp-redash:
+    build: .
+    ports:
+      - "${PORT:-3000}:${PORT:-3000}"
+    env_file:
+      - .env
+    command: ["--streamable-http"]

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,8 @@ export interface Config {
   dataSourceId?: number;
 }
 
+export const PORT = process.env.PORT || 3000;
+
 let config: Config | null = null;
 
 /**

--- a/src/transports/sse.ts
+++ b/src/transports/sse.ts
@@ -5,6 +5,7 @@
 import express, { Request, Response } from 'express';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { createServer } from '../server.js';
+import { PORT } from '../config.js';
 
 export async function startSSE(): Promise<void> {
   const app = express();
@@ -30,7 +31,6 @@ export async function startSSE(): Promise<void> {
     }
   });
 
-  const PORT = process.env.PORT || 3000;
   app.listen(PORT);
   console.error(`Redash MCP Server running on SSE at http://localhost:${PORT}`);
 }

--- a/src/transports/streamable-http.ts
+++ b/src/transports/streamable-http.ts
@@ -7,6 +7,7 @@ import express, { Request, Response, NextFunction } from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { createServer } from '../server.js';
+import { PORT } from '../config.js';
 
 /**
  * セッション未検出時のエラーレスポンス
@@ -141,7 +142,6 @@ export async function startStreamableHttp(): Promise<void> {
     });
   });
 
-  const PORT = process.env.PORT || 3000;
   app.listen(PORT);
   console.error(`Redash MCP Server running on Streamable HTTP at http://localhost:${PORT}/mcp`);
 }


### PR DESCRIPTION
## 概要

Docker ComposeによるStreamable HTTP起動をサポートし、PORT設定の重複定義を解消しました。

## 変更内容

- `docker-compose.yml` を追加し、`.env` の `PORT` でポートマッピングを一括管理できるように
- `config.ts` に `PORT` を一元定義し、`streamable-http.ts` / `sse.ts` の重複定義を解消
- READMEを更新
  - 環境変数セクションに `PORT` を追記
  - Streamable HTTPセクションにDocker Compose起動方法を追加
  - `docker run` による起動例を削除（Docker Composeに一本化）
  - 比較表のポート欄を「デフォルト 3000」に修正