### PR TITLE
保存済みクエリ関連のMCPツール4種を追加

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -71,9 +71,45 @@ export interface DataSource {
 }
 
 /**
+ * 保存済みクエリの型
+ */
+export interface SavedQuery {
+  id: number;
+  name: string;
+  description: string | null;
+  query: string;
+  query_hash: string;
+  data_source_id: number | null;
+  is_archived: boolean;
+  is_draft: boolean;
+  is_safe: boolean;
+  schedule: Record<string, unknown> | null;
+  tags: string[];
+  created_at: string;
+  updated_at: string;
+  latest_query_data_id: number | null;
+  user: {
+    id: number;
+    name: string;
+    email: string;
+  };
+  options: Record<string, unknown>;
+}
+
+/**
+ * 保存済みクエリ一覧のページングレスポンス型
+ */
+export interface SavedQueryListResponse {
+  count: number;
+  page: number;
+  page_size: number;
+  results: SavedQuery[];
+}
+
+/**
  * APIレスポンスの共通型
  */
 export interface ApiResponse<T> {
   status: number;
   data: T;
-} 
+}

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -4,4 +4,5 @@
 
 export * from './queries.js';
 export * from './jobs.js';
-export * from './datasources.js'; 
+export * from './datasources.js';
+export * from './saved-queries.js';

--- a/src/operations/saved-queries.test.ts
+++ b/src/operations/saved-queries.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getQuery,
+  searchQueries,
+  getQueryResultById,
+  getSavedQueryResult,
+} from './saved-queries';
+
+vi.mock('../common/utils.js', () => ({
+  apiGet: vi.fn(),
+}));
+
+vi.mock('../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiKey: 'test-key',
+    baseUrl: 'https://redash.example.com',
+    dataSourceId: 1,
+  }),
+}));
+
+import { apiGet } from '../common/utils';
+
+const mockApiGet = vi.mocked(apiGet);
+
+describe('getQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('保存済みクエリの詳細を取得できる', async () => {
+    const mockQuery = {
+      id: 1,
+      name: 'Test Query',
+      description: 'A test query',
+      query: 'SELECT * FROM users',
+      query_hash: 'abc123',
+      data_source_id: 1,
+      is_archived: false,
+      is_draft: false,
+      is_safe: true,
+      schedule: null,
+      tags: ['test'],
+      created_at: '2026-01-01',
+      updated_at: '2026-01-02',
+      latest_query_data_id: 100,
+      user: { id: 1, name: 'Admin', email: 'admin@example.com' },
+      options: {},
+    };
+    mockApiGet.mockResolvedValue(mockQuery);
+
+    const result = await getQuery(1);
+    expect(result).toEqual(mockQuery);
+    expect(mockApiGet).toHaveBeenCalledWith('/api/queries/1');
+  });
+});
+
+describe('searchQueries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('キーワードでクエリを検索できる', async () => {
+    const mockResponse = {
+      count: 1,
+      page: 1,
+      page_size: 25,
+      results: [
+        {
+          id: 1,
+          name: 'User Query',
+          description: '',
+          query: 'SELECT * FROM users',
+          query_hash: 'abc',
+          data_source_id: 1,
+          is_archived: false,
+          is_draft: false,
+          is_safe: true,
+          schedule: null,
+          tags: [],
+          created_at: '2026-01-01',
+          updated_at: '2026-01-02',
+          latest_query_data_id: null,
+          user: { id: 1, name: 'Admin', email: 'admin@example.com' },
+          options: {},
+        },
+      ],
+    };
+    mockApiGet.mockResolvedValue(mockResponse);
+
+    const result = await searchQueries({ q: 'users' });
+    expect(result).toEqual(mockResponse);
+    expect(mockApiGet).toHaveBeenCalledWith('/api/queries?q=users');
+  });
+
+  it('ページネーションパラメータを指定できる', async () => {
+    mockApiGet.mockResolvedValue({ count: 0, page: 2, page_size: 10, results: [] });
+
+    await searchQueries({ q: 'test', page: 2, page_size: 10 });
+    expect(mockApiGet).toHaveBeenCalledWith('/api/queries?q=test&page=2&page_size=10');
+  });
+});
+
+describe('getQueryResultById', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('クエリ結果をIDで取得できる', async () => {
+    const mockResult = {
+      id: 100,
+      query_hash: 'abc',
+      query: 'SELECT 1',
+      data: { columns: [], rows: [] },
+      data_source_id: 1,
+      runtime: 0.5,
+      retrieved_at: '2026-01-01',
+    };
+    mockApiGet.mockResolvedValue({ query_result: mockResult });
+
+    const result = await getQueryResultById(100);
+    expect(result).toEqual(mockResult);
+    expect(mockApiGet).toHaveBeenCalledWith('/api/query_results/100.json');
+  });
+});
+
+describe('getSavedQueryResult', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('保存済みクエリの最新結果を取得できる', async () => {
+    const mockResult = {
+      id: 200,
+      query_hash: 'def',
+      query: 'SELECT * FROM orders',
+      data: { columns: [{ name: 'id', type: 'integer', friendly_name: 'id' }], rows: [{ id: 1 }] },
+      data_source_id: 1,
+      runtime: 1.2,
+      retrieved_at: '2026-01-01',
+    };
+    mockApiGet.mockResolvedValue({ query_result: mockResult });
+
+    const result = await getSavedQueryResult(5);
+    expect(result).toEqual(mockResult);
+    expect(mockApiGet).toHaveBeenCalledWith('/api/queries/5/results.json');
+  });
+});

--- a/src/operations/saved-queries.ts
+++ b/src/operations/saved-queries.ts
@@ -1,0 +1,80 @@
+/**
+ * Redashの保存済みクエリ操作関連の機能
+ */
+
+import { z } from 'zod';
+import { apiGet } from '../common/utils.js';
+import { SavedQuery, SavedQueryListResponse, QueryResult } from '../common/types.js';
+
+/**
+ * 保存済みクエリ取得パラメータのスキーマ
+ */
+export const GetQuerySchema = z.object({
+  query_id: z.number(),
+});
+
+/**
+ * クエリ検索パラメータのスキーマ
+ */
+export const SearchQueriesSchema = z.object({
+  q: z.string(),
+  page: z.number().optional(),
+  page_size: z.number().optional(),
+});
+
+/**
+ * クエリ結果ID指定取得パラメータのスキーマ
+ */
+export const GetQueryResultSchema = z.object({
+  query_result_id: z.number(),
+});
+
+/**
+ * 保存済みクエリの最新結果取得パラメータのスキーマ
+ */
+export const GetSavedQueryResultSchema = z.object({
+  query_id: z.number(),
+});
+
+/**
+ * 保存済みクエリの詳細を取得する
+ */
+export async function getQuery(queryId: number): Promise<SavedQuery> {
+  return apiGet<SavedQuery>(`/api/queries/${queryId}`);
+}
+
+/**
+ * クエリをキーワード検索する
+ */
+export async function searchQueries(
+  params: z.infer<typeof SearchQueriesSchema>
+): Promise<SavedQueryListResponse> {
+  const searchParams = new URLSearchParams({ q: params.q });
+  if (params.page !== undefined) {
+    searchParams.set('page', String(params.page));
+  }
+  if (params.page_size !== undefined) {
+    searchParams.set('page_size', String(params.page_size));
+  }
+  return apiGet<SavedQueryListResponse>(`/api/queries?${searchParams.toString()}`);
+}
+
+/**
+ * クエリ結果をIDで取得する（再実行なし）
+ */
+export async function getQueryResultById(queryResultId: number): Promise<QueryResult> {
+  const response = await apiGet<{ query_result: QueryResult }>(
+    `/api/query_results/${queryResultId}.json`
+  );
+  return response.query_result;
+}
+
+/**
+ * 保存済みクエリの最新キャッシュ結果を取得する
+ */
+export async function getSavedQueryResult(queryId: number): Promise<QueryResult> {
+  const response = await apiGet<{ query_result: QueryResult }>(
+    `/api/queries/${queryId}/results.json`
+  );
+  return response.query_result;
+}

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -14,6 +14,17 @@ vi.mock('./operations/datasources.js', () => ({
   getDataSource: vi.fn(),
 }));
 
+vi.mock('./operations/saved-queries.js', () => ({
+  GetQuerySchema: { parse: vi.fn() },
+  SearchQueriesSchema: { parse: vi.fn() },
+  GetQueryResultSchema: { parse: vi.fn() },
+  GetSavedQueryResultSchema: { parse: vi.fn() },
+  getQuery: vi.fn(),
+  searchQueries: vi.fn(),
+  getQueryResultById: vi.fn(),
+  getSavedQueryResult: vi.fn(),
+}));
+
 vi.mock('./common/errors.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./common/errors')>();
   return actual;

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 
 import * as queries from './operations/queries.js';
 import * as datasources from './operations/datasources.js';
+import * as savedQueries from './operations/saved-queries.js';
 import { RedashError, isRedashError } from './common/errors.js';
 
 const VERSION = '1.0.0';
@@ -75,6 +76,26 @@ export function createServer(): Server {
           description: 'Get details about a specific data source',
           inputSchema: zodToJsonSchema(datasources.DataSourceSchema),
         },
+        {
+          name: 'get_query',
+          description: 'Get details of a saved query by its ID, including the SQL text',
+          inputSchema: zodToJsonSchema(savedQueries.GetQuerySchema),
+        },
+        {
+          name: 'search_queries',
+          description: 'Search saved queries by keyword',
+          inputSchema: zodToJsonSchema(savedQueries.SearchQueriesSchema),
+        },
+        {
+          name: 'get_query_result',
+          description: 'Get an existing query result by its result ID without re-executing the query',
+          inputSchema: zodToJsonSchema(savedQueries.GetQueryResultSchema),
+        },
+        {
+          name: 'get_saved_query_result',
+          description: 'Get the latest cached result of a saved query by its query ID',
+          inputSchema: zodToJsonSchema(savedQueries.GetSavedQueryResultSchema),
+        },
       ],
     };
   });
@@ -100,6 +121,34 @@ export function createServer(): Server {
           const source = await datasources.getDataSource(args.data_source_id);
           return {
             content: [{ type: 'text', text: JSON.stringify(source, null, 2) }],
+          };
+        }
+        case 'get_query': {
+          const args = savedQueries.GetQuerySchema.parse(request.params.arguments);
+          const query = await savedQueries.getQuery(args.query_id);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(query, null, 2) }],
+          };
+        }
+        case 'search_queries': {
+          const args = savedQueries.SearchQueriesSchema.parse(request.params.arguments);
+          const results = await savedQueries.searchQueries(args);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
+          };
+        }
+        case 'get_query_result': {
+          const args = savedQueries.GetQueryResultSchema.parse(request.params.arguments);
+          const result = await savedQueries.getQueryResultById(args.query_result_id);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          };
+        }
+        case 'get_saved_query_result': {
+          const args = savedQueries.GetSavedQueryResultSchema.parse(request.params.arguments);
+          const result = await savedQueries.getSavedQueryResult(args.query_id);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
           };
         }
         default:


### PR DESCRIPTION
## 概要

保存済みクエリの検索・参照・結果取得を可能にする4つのMCPツールを追加しました。

## 追加ツール

| ツール名 | パラメータ | 説明 |
|---------|-----------|------|
| `get_query` | `query_id` | 保存済みクエリの詳細（SQL文含む）を取得 |
| `search_queries` | `q`, `page?`, `page_size?` | キーワードで保存済みクエリを検索 |
| `get_query_result` | `query_result_id` | 既存のクエリ結果をIDで取得（再実行なし） |
| `get_saved_query_result` | `query_id` | 保存済みクエリの最新キャッシュ結果を取得 |

## 変更内容

- `src/operations/saved-queries.ts`: 4ツールのAPI操作実装
- `src/operations/saved-queries.test.ts`: ユニットテスト（5ケース）
- `src/common/types.ts`: `SavedQuery`, `SavedQueryListResponse` 型を追加
- `src/operations/index.ts`: エクスポート追加
- `src/server.ts`: ツール定義とハンドラを追加
- `src/server.test.ts`: 新規ツールのモック追加

## テスト

- 全53テスト通過
- ビルド・型チェック・lint 通過
- Codexによるレビュー済み（p1: nullable型修正対応済み）