### PR TITLE
app.listenでIPv6デュアルスタック対応

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ export interface Config {
   dataSourceId?: number;
 }
 
-export const PORT = process.env.PORT || 3000;
+export const PORT = Number(process.env.PORT) || 3000;
 
 let config: Config | null = null;
 

--- a/src/transports/sse.ts
+++ b/src/transports/sse.ts
@@ -31,6 +31,7 @@ export async function startSSE(): Promise<void> {
     }
   });
 
-  app.listen(PORT);
-  console.error(`Redash MCP Server running on SSE at http://localhost:${PORT}`);
+  app.listen(PORT, '::', () => {
+    console.error(`Redash MCP Server running on SSE at http://localhost:${PORT}`);
+  });
 }

--- a/src/transports/streamable-http.ts
+++ b/src/transports/streamable-http.ts
@@ -142,6 +142,7 @@ export async function startStreamableHttp(): Promise<void> {
     });
   });
 
-  app.listen(PORT);
-  console.error(`Redash MCP Server running on Streamable HTTP at http://localhost:${PORT}/mcp`);
+  app.listen(PORT, '::', () => {
+    console.error(`Redash MCP Server running on Streamable HTTP at http://localhost:${PORT}/mcp`);
+  });
 }


### PR DESCRIPTION
## Summary
- `app.listen(PORT)` を `app.listen(PORT, '::',  callback)` に変更し、IPv4/IPv6両方でリッスンするように対応
- `PORT` の型を `Number()` で `number` に統一し、TypeScriptの型エラーを解消
- SSE / Streamable HTTP 両トランスポートに適用

## Test plan
- [ ] `docker compose up` でサーバーが正常起動すること
- [ ] IPv4 (`http://localhost:PORT`) でアクセスできること
- [ ] IPv6 (`http://[::1]:PORT`) でアクセスできること